### PR TITLE
Adds `--cert` parameter to specify local trusted certificate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+FROM python:2.7
 
 LABEL maintainer="Trey Duskin <trey@swiftstack.com>"
-
-FROM python:2.7
 
 #set up build env
 WORKDIR /ssapi

--- a/README.md
+++ b/README.md
@@ -11,19 +11,25 @@ controllers via the SwiftStack API
 
 ### Docker
 
-1. Download and install Docker for your platform: [Docker Download Link](https://www.docker.com/community-edition#/download)
-2. Once Docker is installed, get the container image with the command `docker pull swiftstack/ssapi`
-3. After pulling the image, you can run the `ss-util` script as described below by prefixing the command with the `docker run` command, as follows:
+1. Download and install Docker for your platform:
+   [Docker Download Link](https://www.docker.com/community-edition#/download)
+2. Once Docker is installed, get the container image with the command `docker pull
+   swiftstack/ssapi`
+3. After pulling the image, you can run the `ss-util` script as described below by
+   prefixing the command with the `docker run` command, as follows:
 
 ```
 $ docker run swiftstack/ssapi ss-util ...
 ```
 
-The docker image exports a volume called `/output` which can be mapped using the `-v` parameter (e.g. `-v `pwd`:/output`.  This is necessary if writing out files with the utility.
+The docker image exports a volume called `/output` which can be mapped using the `-v`
+parameter (e.g. `-v `pwd`:/output`. This is necessary if writing out files with the
+utility.
 
 ### Install in a Virtualenv
 
-1. Create a new [Virtualenv](https://virtualenv.pypa.io/en/stable/) by running `virtualenv ss-util`
+1. Create a new [Virtualenv](https://virtualenv.pypa.io/en/stable/) by r unning
+   `virtualenv ss-util`
 2. `cd ss-util`
 3. `source ./bin/activate`
 4. Download the latest release from the
@@ -128,7 +134,7 @@ AUTH_user100,2,2453326,3063,2017-06-01 08:00:00Z,2591101721504170,2017-06-01 07:
 
 ### Filtering Utilization Output
 Raw and summary utilization output columns can also be optionally controlled with the
-`-f`, `--fields` parameter.  Specify columns using space-separated single letters which map
+`-f`, `--fields` parameter. Specify columns using space-separated single letters which map
 to the following:
 
 ```
@@ -167,8 +173,8 @@ AUTH_swiftstack,45
 
 ### Using Environment Variables
 
-`ss-utilization` supports setting some parameters via environment variables instead of using the
-command-line parameters. These are:
+`ss-utilization` supports setting some parameters via environment variables instead of
+using the command-line parameters. These are:
 
 - `SSAPI_CONTROLLER`: Hostname of controller (`-m` param)
 - `SSAPI_CLUSTER`: ID of cluster (`-c` param)
@@ -227,8 +233,8 @@ required arguments:
 ## Known Limitations
 
 Currently, it is required to know what timezone the cluster is in (or how the performance
-period is defined) and use that in the timestamp offsets in the start and end parameters. The
-SwiftStack API will return everything in UTC.
+period is defined) and use that in the timestamp offsets in the start and end parameters.
+The SwiftStack API will return everything in UTC.
 
 Also, there is currently no way in the SwiftStack API to query what policies are in use on
 a particular cluster, so this information must be known.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ utility.
 
 ### Install in a Virtualenv
 
-1. Create a new [Virtualenv](https://virtualenv.pypa.io/en/stable/) by r unning
-   `virtualenv ss-util`
+1. Create a new [Virtualenv](https://virtualenv.pypa.io/en/stable/) by running `virtualenv
+   ss-util`
 2. `cd ss-util`
 3. `source ./bin/activate`
 4. Download the latest release from the

--- a/README.md
+++ b/README.md
@@ -205,11 +205,11 @@ providing a quasi-config file.
 
 ### Command-line Parameter Reference
 ```
-usage: ss-util [-h] [-m CONTROLLER_HOST] [-c CLUSTER_ID] [-u SSAPI_USER]
-               [-k SSAPI_KEY] -s START_DATETIME -e END_DATETIME -p
-               STORAGE_POLICY [STORAGE_POLICY ...] [-o OUTPUT_FILE]
-               [-f {a,c,b,e,o,p,s} [{a,c,b,e,o,p,s} ...]] [--raw] [-V] [-v]
-               [-q]
+usage: ss-util [-h] -m CONTROLLER_HOST -c CLUSTER_ID -u SSAPI_USER -k
+               SSAPI_KEY -s START_DATETIME -e END_DATETIME -p STORAGE_POLICY
+               [STORAGE_POLICY ...] [-o OUTPUT_FILE]
+               [-f {a,c,b,e,o,p,s} [{a,c,b,e,o,p,s} ...]] [--raw]
+               [--accountonly] [--cert CONTROLLER_CERT_PATH] [-V] [-v] [-q]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -220,8 +220,11 @@ optional arguments:
                         output format columns to include: a: account, c:
                         container_count, b: bytes_used, e: end, o:
                         object_count, p: policy, s: start,
-  --accountonly         output account only information
   --raw                 output raw hourly utilization hours; don't summarize
+  --accountonly         output account only, not utilization hours; not
+                        summarize
+  --cert CONTROLLER_CERT_PATH
+                        path to controller SSL cert (e.g. if self-signed)
   -V, --version         print version and exit
   -v, --verbose         verbose log messages
   -q, --quiet           disable all logging (overrides verbose)

--- a/README.md
+++ b/README.md
@@ -93,6 +93,25 @@ user103,2017-05-31 19:00:00Z,2017-06-30 19:00:00Z,0,0,0
 ### Account Only Output
 If required the `--accountonly` parameter can be used to get account only information.
 
+### SSL Certificate Validation
+By default, `ssapi` will assume the controller SSL certificate is signed by a known
+authority. However, if the controller certificate is self-signed (or signed by a private
+CA), the `--cert` option can be used to specify the certificate to trust locally. For
+example, you can download the self-signed certificate from the controller to your local
+directory and then then use it in the `ss-util` command, e.g.:
+
+```
+$ scp controller:/opt/ss/etc/ssman.crt ./
+$ ss-util --cert ./ssman.crt ...
+```
+
+Note if you are running the Dockerized version of this tool, you will need to map the
+local directory to a working dir, e.g.:
+
+```
+$ docker run -w /workdir -v $(pwd):/workdir swiftstack/ssapi ss-util --cert ./ssman.crt ...
+```
+
 ### Raw Utilizataion Output
 If required the `--raw` parameter can be used to get raw account-policy-hourly utilization
 information.

--- a/swiftstackapi/api.py
+++ b/swiftstackapi/api.py
@@ -24,11 +24,15 @@ logger = logging.getLogger(__name__)
 
 
 class SwiftStackAPIClient(object):
-    def __init__(self, controller, apiuser, apikey):
+    def __init__(self, controller, apiuser, apikey, controller_cert=None):
         self.endpoint = "https://" + controller + "/api/v1/"
         self.apiuser = apiuser
         self.apikey = apikey
         self.session = requests.Session()
+
+        if controller_cert:
+            self.session.verify = controller_cert
+
         headers = {'Authorization': 'apikey %s:%s' % (self.apiuser, self.apikey)}
 
         self.session.headers.update(headers)

--- a/swiftstackapi/cli.py
+++ b/swiftstackapi/cli.py
@@ -237,49 +237,56 @@ def main(args=None):
                                                   policy=p)
             logger.info("Got %d accounts in utilization period for policy %s" %
                         (len(util_accts), p))
-            if config.account_output is False:
-                for account in util_accts:
-                    if account not in util_output:
-                        util_output[account] = {}
-                    records = ssapiclient.get_acct_util(cluster=config.cluster_id,
-                                                        account=account,
-                                                        start_time=config.start_datetime,
-                                                        end_time=config.end_datetime,
-                                                        policy=p)
-                    util_output[account][p] = records
-                    logger.info("Got %d records for account %s in policy %s" % (len(records),
-                                                                                account,
-                                                                                p))
 
-        if config.output_file:
-            with open(config.output_file, 'wb') as f:
+            if len(util_accts) > 0:
+                if config.account_output is False:
+                    for account in util_accts:
+                        if account not in util_output:
+                            util_output[account] = {}
+                        records = ssapiclient.get_acct_util(cluster=config.cluster_id,
+                                                            account=account,
+                                                            start_time=config.start_datetime,
+                                                            end_time=config.end_datetime,
+                                                            policy=p)
+                        util_output[account][p] = records
+                        logger.info("Got %d records for account %s in policy %s" % (len(records),
+                                                                                    account,
+                                                                                    p))
+            else:
+                logger.warn("No accounts found in utilization period for policy %s" % p)
+
+        if util_output:
+            if config.output_file:
+                with open(config.output_file, 'wb') as f:
+                    if config.account_output:
+                        capture_fields = ['account']
+                        writer = output.CsvUtilizationWriter(util_accts, f, output_fields=capture_fields)
+                        writer.write_accountonly_csv()
+                    else:
+                        writer = output.CsvUtilizationWriter(util_output, f, output_fields=capture_fields)
+                        if config.raw_output:
+                            writer.write_raw_csv()
+                        else:
+                            writer.write_summary_csv()
+                    logger.info("Wrote %s" % config.output_file)
+            else:
+                fake_csvfile = StringIO.StringIO()
                 if config.account_output:
                     capture_fields = ['account']
-                    writer = output.CsvUtilizationWriter(util_accts, f, output_fields=capture_fields)
+                    writer = output.CsvUtilizationWriter(util_accts, fake_csvfile,
+                                                         output_fields=capture_fields)
                     writer.write_accountonly_csv()
                 else:
-                    writer = output.CsvUtilizationWriter(util_output, f, output_fields=capture_fields)
+                    writer = output.CsvUtilizationWriter(util_output, fake_csvfile,
+                                                         output_fields=capture_fields)
                     if config.raw_output:
                         writer.write_raw_csv()
                     else:
                         writer.write_summary_csv()
-                logger.info("Wrote %s" % config.output_file)
+                print fake_csvfile.getvalue()
+                fake_csvfile.close()
         else:
-            fake_csvfile = StringIO.StringIO()
-            if config.account_output:
-                capture_fields = ['account']
-                writer = output.CsvUtilizationWriter(util_accts, fake_csvfile,
-                                                     output_fields=capture_fields)
-                writer.write_accountonly_csv()
-            else:
-                writer = output.CsvUtilizationWriter(util_output, fake_csvfile,
-                                                     output_fields=capture_fields)
-                if config.raw_output:
-                    writer.write_raw_csv()
-                else:
-                    writer.write_summary_csv()
-            print fake_csvfile.getvalue()
-            fake_csvfile.close()
+            logger.error("No utilization data found in specified time range!")
 
     except:
         raise

--- a/swiftstackapi/cli.py
+++ b/swiftstackapi/cli.py
@@ -163,6 +163,8 @@ def parse_args(args):
     parser.add_argument('--accountonly', help="output account only, not utilization hours; not summarize",
                         action='store_true',
                         dest="account_output")
+    parser.add_argument('--cert', help="path to controller SSL cert (e.g. if self-signed)",
+                        type=str, dest="controller_cert_path", default=None)
     parser.add_argument('-V', '--version', help='print version and exit',
                         action='version',
                         version='%(prog)s ' + version.version)
@@ -224,7 +226,8 @@ def main(args=None):
     try:
         ssapiclient = api.SwiftStackAPIClient(controller=config.controller_host,
                                               apiuser=config.ssapi_user,
-                                              apikey=config.ssapi_key)
+                                              apikey=config.ssapi_key,
+                                              controller_cert=config.controller_cert_path)
         # TODO: all this logic needs to be in some unit-testable function!!
         util_output = {}
         for p in config.storage_policy:


### PR DESCRIPTION
This merge will add a new `--cert` flag to `ss-util` that will allow a user to specify a local SSL certificate file to trust when connecting to the SwiftStack API on a controller.  By default, controller SSL certs are self-signed and if they aren't replaced by a real (i.e. signed by a trusted authority) certificate, the requests library will give an error.

This approach was chosen instead of allowing insecure connections as a less-weak approach to dealing with self-signed certs.

Fixes #17 